### PR TITLE
Fix breadcrumbs

### DIFF
--- a/dotnet/breadcrumb/toc.yml
+++ b/dotnet/breadcrumb/toc.yml
@@ -1,7 +1,0 @@
-- name: Learn
-  tocHref: /
-  topicHref: /
-  items:
-  - name: Windows
-    tocHref: /dotnet/
-    topicHref: /windows/index

--- a/dotnet/community-toolkit-dotnet-breadcrumb/toc.yml
+++ b/dotnet/community-toolkit-dotnet-breadcrumb/toc.yml
@@ -1,0 +1,7 @@
+- name: Windows
+  tocHref: /dotnet/
+  topicHref: /windows/index
+  items:
+  - name: .NET API browser
+    tocHref: /dotnet/
+    topicHref: /dotnet/api/index

--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -41,7 +41,7 @@
     },
     "xrefService": [ "https://xref.docs.microsoft.com/query?uid={uid}" ],
     "globalMetadata": {
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "breadcrumb_path": "/dotnet/community-toolkit-dotnet-breadcrumb/toc.json",
       "apiPlatform": "dotnet",
       "ms.topic": "managed-reference",
       "ms.prod": "community-toolkit",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 