### PR TITLE
Update ValueTypeExtensions.xml fixing incorrect word

### DIFF
--- a/dotnet/xml/Microsoft.Toolkit.Extensions/ValueTypeExtensions.xml
+++ b/dotnet/xml/Microsoft.Toolkit.Extensions/ValueTypeExtensions.xml
@@ -55,7 +55,7 @@
             The hexadecimal representation of <paramref name="value" /> (with the '0x' prefix), left-padded to byte boundaries and ordered as big-endian.
             </returns>
         <remarks>
-            As a byte (8 bits) is represented by two hexadecimal digits (each representing a group of 4 bytes), each <see cref="T:System.String" />
+            As a byte (8 bits) is represented by two hexadecimal digits (each representing a group of 4 bits), each <see cref="T:System.String" />
             representation will always contain an even number of digits. For instance:
             <code>
             Console.WriteLine(1.ToHexString()); // "0x01"


### PR DESCRIPTION
Corrects a usage of "bytes" to "bits" in ValueTypeExtensions.xml